### PR TITLE
implementation plan for filtering ECS scheduler notifications

### DIFF
--- a/docs/EVENTBRIDGE_RULE_EXPLAINED.md
+++ b/docs/EVENTBRIDGE_RULE_EXPLAINED.md
@@ -1,0 +1,175 @@
+````# EventBridge Rule 동작 방식
+
+이 문서는 `aws_cloudwatch_event_rule`이 ECS UpdateService 이벤트를 필터링하는 방식을 설명합니다.
+
+## 1. 전체 아키텍처 흐름
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              AWS 내부                                        │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  EventBridge Scheduler                                                      │
+│        │                                                                    │
+│        ▼ (IAM Role: *-scheduler-role-dev)                                  │
+│  ┌───────────┐                                                             │
+│  │    ECS    │ UpdateService API 호출                                       │
+│  └───────────┘                                                             │
+│        │                                                                    │
+│        ▼ (자동 기록)                                                         │
+│  ┌───────────┐                                                             │
+│  │CloudTrail │ 모든 API 호출 기록                                            │
+│  └───────────┘                                                             │
+│        │                                                                    │
+│        ▼ (이벤트 발행)                                                       │
+│  ┌───────────────────────────────────────┐                                 │
+│  │         EventBridge (Default Bus)      │                                 │
+│  │                                        │                                 │
+│  │   ┌────────────────────────────────┐  │                                 │
+│  │   │  aws_cloudwatch_event_rule     │  │  ← 여기서 필터링!                 │
+│  │   │  - source: aws.ecs             │  │                                 │
+│  │   │  - eventName: UpdateService    │  │                                 │
+│  │   │  - userName suffix 매칭         │  │                                 │
+│  │   └────────────────────────────────┘  │                                 │
+│  └───────────────────────────────────────┘                                 │
+│        │                                                                    │
+│        ▼ (매칭된 이벤트만)                                                    │
+│  ┌───────────┐                                                             │
+│  │    SQS    │ 메시지 배치 (10개 또는 5분)                                    │
+│  └───────────┘                                                             │
+│        │                                                                    │
+│        ▼                                                                    │
+│  ┌───────────┐                                                             │
+│  │  Lambda   │ 배치 처리 → Slack 전송                                        │
+│  └───────────┘                                                             │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 2. Event Rule의 핵심: event_pattern
+
+```hcl
+event_pattern = jsonencode({
+  source      = ["aws.ecs"]                           # ① 이벤트 소스
+  detail-type = ["AWS API Call via CloudTrail"]       # ② 이벤트 타입
+  detail = {
+    eventName = ["UpdateService"]                     # ③ API 이름
+    userIdentity = {
+      sessionContext = {
+        sessionIssuer = {
+          userName = [{ "suffix": "-scheduler-role-${var.environment}" }]  # ④ 호출자 필터
+        }
+      }
+    }
+  }
+})
+```
+
+### 각 필드 설명
+
+| 필드 | 역할 | 예시 값 |
+|------|------|---------|
+| `source` | AWS 서비스 식별 | `aws.ecs`, `aws.ec2` 등 |
+| `detail-type` | 이벤트 유형 | CloudTrail API 호출 |
+| `eventName` | 어떤 API가 호출됐는지 | `UpdateService` |
+| `userName` | 누가 호출했는지 (IAM Role 이름) | suffix로 `-scheduler-role-dev` |
+
+## 3. 실제 CloudTrail 이벤트 예시
+
+EventBridge로 들어오는 실제 이벤트:
+
+```json
+{
+  "source": "aws.ecs",
+  "detail-type": "AWS API Call via CloudTrail",
+  "detail": {
+    "eventName": "UpdateService",
+    "userIdentity": {
+      "type": "AssumedRole",
+      "sessionContext": {
+        "sessionIssuer": {
+          "type": "Role",
+          "userName": "nestjs-scheduler-role-dev"
+        }
+      }
+    },
+    "requestParameters": {
+      "cluster": "my-cluster",
+      "service": "nestjs-service",
+      "desiredCount": 1
+    }
+  }
+}
+```
+
+> `userName` 필드가 suffix 패턴 `-scheduler-role-dev`와 매칭됩니다.
+
+## 4. 매칭 로직 (AND 조건)
+
+```
+source = "aws.ecs"
+    AND
+detail-type = "AWS API Call via CloudTrail"
+    AND
+eventName = "UpdateService"
+    AND
+userName이 "-scheduler-role-dev"로 끝남
+```
+
+**모든 조건이 만족해야** Target(SQS)으로 전달됩니다.
+
+## 5. Target 연결
+
+```hcl
+resource "aws_cloudwatch_event_target" "send_to_sqs" {
+  rule      = aws_cloudwatch_event_rule.ecs_update_service.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.alerts.arn  # 매칭된 이벤트 → SQS로 전송
+}
+```
+
+Rule이 매칭되면 SQS Queue로 이벤트 JSON 전체가 메시지로 들어갑니다.
+
+## 6. 기존 패턴과의 비교
+
+### 기존 패턴 (UpdateService만)
+
+```hcl
+event_pattern = {
+  source      = ["aws.ecs"]
+  detail-type = ["AWS API Call via CloudTrail"]
+  detail = {
+    eventName = ["UpdateService"]
+  }
+}
+```
+
+**매칭되는 경우:**
+- EventBridge Scheduler가 호출한 UpdateService
+- AWS 콘솔에서 수동으로 UpdateService
+- AWS CLI로 직접 UpdateService
+- CI/CD 파이프라인에서 UpdateService
+
+→ **모든 UpdateService 호출**에 대해 Slack 알림 발생
+
+### 새 패턴 (suffix 필터 추가)
+
+**매칭되는 경우:**
+- `nestjs-scheduler-role-dev` 같은 스케줄러 IAM Role이 호출한 경우만
+
+**매칭 안 되는 경우:**
+- AWS 콘솔에서 수동 조작
+- AWS CLI 직접 호출
+- CI/CD 파이프라인 (다른 Role 사용)
+
+## 7. 요약
+
+| 단계 | 컴포넌트 | 역할 |
+|------|----------|------|
+| 1 | CloudTrail | 모든 AWS API 호출 기록 |
+| 2 | EventBridge | CloudTrail 이벤트를 실시간 수신 |
+| 3 | **Event Rule** | **패턴 매칭으로 필터링** |
+| 4 | Event Target | 매칭된 이벤트를 SQS로 라우팅 |
+| 5 | SQS | 메시지 배치 |
+| 6 | Lambda | 배치 처리 후 Slack 전송 |
+````

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,223 @@
+# ECS Scheduler 알림 배칭 구현 계획
+
+## 현재 상황
+
+- **서비스 수**: dev/stg 각 20개, 최대 50개 예정
+- **문제점**:
+  1. Slack Webhook Rate Limit (1 req/sec) → 알림 누락 가능
+  2. 09:00/18:00에 20~50개 알림 폭주 → 채널 마비
+  3. ECS API 동시 호출 → Throttling 가능성
+
+---
+
+## 목표 아키텍처
+
+### 변경 전
+```
+EventBridge Scheduler → ECS UpdateService
+CloudTrail → EventBridge Rule → SNS → Lambda → Slack (개별 알림 N개)
+```
+
+### 변경 후
+```
+EventBridge Scheduler (5분 분산) → ECS UpdateService
+CloudTrail → EventBridge Rule → SQS (배칭) → Lambda → Slack (요약 알림 1개)
+```
+
+---
+
+## 변경 사항 요약
+
+| 구분 | 현재 | 변경 후 |
+|------|------|---------|
+| 스케줄 실행 | 정확한 시간 | 5분 내 분산 (flexible_time_window) |
+| 알림 전달 | SNS → Lambda | SQS → Lambda (batch) |
+| 알림 형태 | 개별 알림 N개 | 요약 알림 1개 |
+| Lambda 트리거 | SNS (즉시) | SQS (5분 대기 또는 10개 모임) |
+
+---
+
+## 구현 단계
+
+### Phase 1: ECS Scheduler 시간 분산 적용
+
+**파일**: `modules/ecs-scheduler/main.tf`
+
+**변경 내용**:
+```hcl
+# 변경 전
+flexible_time_window {
+  mode = "OFF"
+}
+
+# 변경 후
+flexible_time_window {
+  mode                      = "FLEXIBLE"
+  maximum_window_in_minutes = 5
+}
+```
+
+**효과**:
+- 50개 서비스가 09:00~09:05 사이에 분산 실행
+- ECS UpdateService API throttling 방지
+
+---
+
+### Phase 2: slack-notifier 모듈 재구성
+
+**파일**: `modules/slack-notifier/main.tf`
+
+#### 2-1. SNS → SQS로 변경
+
+```hcl
+# 새로 추가
+resource "aws_sqs_queue" "alerts" {
+  name                       = "${var.name_prefix}-alerts-${var.environment}"
+  visibility_timeout_seconds = 60
+  message_retention_seconds  = 3600  # 1시간
+}
+
+# EventBridge Target을 SQS로 변경
+resource "aws_cloudwatch_event_target" "send_to_sqs" {
+  rule      = aws_cloudwatch_event_rule.ecs_update_service.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.alerts.arn
+}
+```
+
+#### 2-2. Lambda 트리거를 SQS Batch로 변경
+
+```hcl
+resource "aws_lambda_event_source_mapping" "sqs_trigger" {
+  event_source_arn                   = aws_sqs_queue.alerts.arn
+  function_name                      = aws_lambda_function.slack_notifier.arn
+  batch_size                         = 10              # 최대 10개씩 처리
+  maximum_batching_window_in_seconds = 300             # 5분 대기
+  enabled                            = true
+}
+```
+
+**동작 방식**:
+- 메시지가 10개 모이면 즉시 Lambda 실행
+- 또는 5분(300초) 지나면 모인 메시지들로 Lambda 실행
+- 둘 중 먼저 충족되는 조건으로 트리거
+
+---
+
+### Phase 3: Lambda 함수 수정
+
+**파일**: `modules/slack-notifier/lambda/index.py`
+
+**변경 내용**: 배치 메시지 처리 + 요약 알림 생성
+
+```python
+def handler(event, context):
+    # SQS에서 여러 메시지를 배치로 받음
+    records = event.get('Records', [])
+
+    results = []
+    for record in records:
+        # 각 CloudTrail 이벤트 파싱
+        body = json.loads(record['body'])
+        detail = body.get('detail', {})
+        # ... 파싱 로직
+        results.append({
+            'service': service_name,
+            'action': action,
+            'status': status,
+            'error': error_message
+        })
+
+    # 요약 메시지 생성 및 전송
+    send_summary_to_slack(results)
+```
+
+---
+
+### Phase 4: 기존 SNS 리소스 정리
+
+**삭제할 리소스**:
+- `aws_sns_topic.alerts`
+- `aws_sns_topic_subscription.slack`
+- `aws_lambda_permission.allow_sns`
+- `aws_sns_topic_policy.allow_eventbridge`
+
+---
+
+## 예상 알림 형태
+
+### 변경 전 (20개 개별 알림)
+```
+✅ ECS Scheduling Succeeded
+Service: nestjs
+Action: Scale Up (→ 1)
+...
+
+✅ ECS Scheduling Succeeded
+Service: python-api
+Action: Scale Up (→ 1)
+...
+
+(... 18개 더 ...)
+```
+
+### 변경 후 (1개 요약 알림)
+```
+📊 ECS Scheduled Scaling Summary
+Time: 2024-01-15 09:00~09:05 KST
+Environment: dev
+
+┌─────────────────┬────────────┬──────────┐
+│ Service         │ Action     │ Status   │
+├─────────────────┼────────────┼──────────┤
+│ nestjs          │ Scale Up   │ ✅       │
+│ python-api      │ Scale Up   │ ✅       │
+│ worker-service  │ Scale Up   │ ✅       │
+│ frontend        │ Scale Up   │ ❌ Error │
+│ ... (16 more)   │ Scale Up   │ ✅       │
+└─────────────────┴────────────┴──────────┘
+
+Total: 19 succeeded, 1 failed
+
+❌ Failures:
+• frontend: ResourceNotFoundException - Service not found
+```
+
+---
+
+## 작업 순서
+
+1. [ ] Phase 1: `ecs-scheduler` 모듈에 flexible_time_window 적용
+2. [ ] Phase 2-1: `slack-notifier`에 SQS 리소스 추가
+3. [ ] Phase 2-2: Lambda SQS 트리거 설정
+4. [ ] Phase 3: Lambda 함수 배치 처리 로직으로 수정
+5. [ ] Phase 4: 기존 SNS 리소스 제거
+6. [ ] 테스트: dev 환경에서 검증
+7. [ ] stg 환경 적용
+
+---
+
+## 롤백 계획
+
+문제 발생 시:
+1. `flexible_time_window`를 `OFF`로 변경
+2. SQS 트리거 비활성화
+3. SNS 리소스 복구 (git revert)
+
+---
+
+## 예상 비용 변화
+
+| 서비스 | 변경 전 | 변경 후 |
+|--------|---------|---------|
+| SNS | $0.50/월 | $0 |
+| SQS | $0 | ~$1/월 (Free tier 내) |
+| Lambda | 동일 | 동일 (호출 수 감소) |
+
+**총 비용 변화**: 거의 없음 (SQS Free tier: 월 100만 요청)
+
+---
+
+## 다음 단계
+
+이 계획이 괜찮으시면 Phase 1부터 구현을 시작하겠습니다.

--- a/docs/IMPLEMENTATION_REPORT.md
+++ b/docs/IMPLEMENTATION_REPORT.md
@@ -1,0 +1,246 @@
+# ECS Scheduler 알림 배칭 구현 완료 보고서
+
+**작성일**: 2025-12-13
+**상태**: 완료
+
+---
+
+## 개요
+
+ECS 서비스 스케줄링 알림을 개별 전송에서 배칭 방식으로 변경하여, 다수의 서비스(20~50개)가 동시에 스케줄링될 때 발생하는 알림 폭주 문제를 해결했습니다.
+
+---
+
+## 변경 사항 요약
+
+### 아키텍처 변경
+
+```
+[변경 전]
+EventBridge Scheduler → ECS UpdateService
+CloudTrail → EventBridge Rule → SNS → Lambda → Slack (개별 알림 N개)
+
+[변경 후]
+EventBridge Scheduler (5분 분산) → ECS UpdateService
+CloudTrail → EventBridge Rule → SQS (배칭) → Lambda → Slack (요약 알림 1개)
+```
+
+### 변경된 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `modules/ecs-scheduler/variables.tf` | `flexible_time_window_minutes` 변수 추가 |
+| `modules/ecs-scheduler/main.tf` | flexible_time_window 동적 설정 적용 |
+| `modules/slack-notifier/variables.tf` | `batch_size`, `batching_window_seconds` 변수 추가 |
+| `modules/slack-notifier/main.tf` | SNS → SQS 변경, Lambda Event Source Mapping 추가 |
+| `modules/slack-notifier/outputs.tf` | SNS output → SQS output 변경 |
+| `modules/slack-notifier/lambda/index.py` | 배치 처리 및 요약 알림 로직 구현 |
+
+---
+
+## 상세 변경 내용
+
+### 1. ecs-scheduler 모듈
+
+#### 새로운 변수
+
+```hcl
+variable "flexible_time_window_minutes" {
+  description = "Maximum window in minutes for flexible scheduling (0 = OFF, 1-60 = FLEXIBLE)"
+  type        = number
+  default     = 5
+}
+```
+
+#### 스케줄 설정 변경
+
+```hcl
+flexible_time_window {
+  mode                      = var.flexible_time_window_minutes > 0 ? "FLEXIBLE" : "OFF"
+  maximum_window_in_minutes = var.flexible_time_window_minutes > 0 ? var.flexible_time_window_minutes : null
+}
+```
+
+**효과**: 50개 서비스가 09:00~09:05 사이에 자동 분산 실행되어 ECS API throttling 방지
+
+---
+
+### 2. slack-notifier 모듈
+
+#### 새로운 변수
+
+```hcl
+variable "batch_size" {
+  description = "Maximum number of messages to batch before sending to Slack"
+  type        = number
+  default     = 10
+}
+
+variable "batching_window_seconds" {
+  description = "Maximum time in seconds to wait for batching messages"
+  type        = number
+  default     = 300  # 5분
+}
+```
+
+#### 리소스 변경
+
+| 삭제됨 | 추가됨 |
+|--------|--------|
+| `aws_sns_topic.alerts` | `aws_sqs_queue.alerts` |
+| `aws_sns_topic_subscription.slack` | `aws_sqs_queue_policy.allow_eventbridge` |
+| `aws_lambda_permission.allow_sns` | `aws_iam_role_policy.lambda_sqs` |
+| `aws_sns_topic_policy.allow_eventbridge` | `aws_lambda_event_source_mapping.sqs_trigger` |
+| `aws_cloudwatch_event_target.send_to_sns` | `aws_cloudwatch_event_target.send_to_sqs` |
+
+#### Lambda Event Source Mapping 설정
+
+```hcl
+resource "aws_lambda_event_source_mapping" "sqs_trigger" {
+  event_source_arn                   = aws_sqs_queue.alerts.arn
+  function_name                      = aws_lambda_function.slack_notifier.arn
+  batch_size                         = var.batch_size        # 최대 10개
+  maximum_batching_window_in_seconds = var.batching_window_seconds  # 5분 대기
+  enabled                            = true
+}
+```
+
+**트리거 조건**:
+- 메시지 10개 도달 → 즉시 Lambda 호출
+- 5분 경과 → 현재까지 모인 메시지로 Lambda 호출
+
+---
+
+### 3. Lambda 함수 변경
+
+#### 주요 변경점
+
+1. **SQS 배치 처리**: `event['Records']`에서 여러 메시지를 배열로 받아 처리
+2. **요약 알림 생성**: 모든 서비스 결과를 하나의 테이블 형태로 정리
+3. **성공/실패 구분**: 색상 및 아이콘으로 상태 구분
+4. **환경 변수 추가**: `ENVIRONMENT` 변수로 환경 표시
+
+#### 알림 형태 예시
+
+**모두 성공 시**:
+```
+✅ ECS Scheduled Scaling Completed
+
+Environment: DEV
+Total Services: 20 (20 succeeded, 0 failed)
+
+Services:
+✅ `nestjs` - Scale Up (-> 1)
+✅ `python-api` - Scale Up (-> 1)
+✅ `worker` - Scale Up (-> 1)
+... (17 more)
+
+Time: 2025-12-13 09:05:00 KST
+```
+
+**일부 실패 시**:
+```
+⚠️ ECS Scheduled Scaling Partially Completed
+
+Environment: DEV
+Total Services: 20 (19 succeeded, 1 failed)
+
+Services:
+✅ `nestjs` - Scale Up (-> 1)
+✅ `python-api` - Scale Up (-> 1)
+❌ `frontend` - Scale Up (-> 1)
+...
+
+❌ Failure Details:
+- `frontend`: ServiceNotFoundException - Service not found
+
+Time: 2025-12-13 09:05:00 KST
+```
+
+---
+
+## 검증 결과
+
+```bash
+$ terraform fmt -recursive
+# (출력 없음 - 포맷 정상)
+
+$ terraform validate
+Success! The configuration is valid.
+```
+
+---
+
+## 배포 단계
+
+### 1. dev 환경 배포
+
+```bash
+cd environments/dev
+terraform init
+terraform plan
+terraform apply
+```
+
+### 2. stg 환경 배포
+
+```bash
+cd environments/stg
+terraform init
+terraform plan
+terraform apply
+```
+
+---
+
+## 주의사항
+
+### 기존 리소스 삭제
+
+`terraform apply` 시 다음 리소스가 삭제됩니다:
+- `aws_sns_topic.alerts`
+- `aws_sns_topic_subscription.slack`
+- `aws_lambda_permission.allow_sns`
+- `aws_sns_topic_policy.allow_eventbridge`
+
+### State 변경
+
+기존 SNS 기반 리소스가 SQS 기반으로 교체되므로, `terraform plan` 출력을 반드시 확인하세요.
+
+---
+
+## 롤백 방법
+
+문제 발생 시 Git에서 이전 커밋으로 되돌린 후 재배포:
+
+```bash
+git revert HEAD
+cd environments/dev && terraform apply
+cd environments/stg && terraform apply
+```
+
+---
+
+## 기대 효과
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 알림 수 (20개 서비스 기준) | 20개 | 1개 |
+| Slack Rate Limit 이슈 | 발생 가능 | 해결 |
+| ECS API Throttling | 발생 가능 | 해결 (5분 분산) |
+| 알림 가독성 | 낮음 (개별 알림) | 높음 (요약 테이블) |
+
+---
+
+## 추가 개선 가능 사항
+
+1. **Dead Letter Queue (DLQ)**: SQS 처리 실패 시 재시도를 위한 DLQ 추가
+2. **CloudWatch Alarm**: Lambda 실패 시 별도 알림
+3. **Scale Up/Down 그룹핑**: 같은 배치 내에서도 Scale Up/Down을 분리하여 표시
+
+---
+
+## 관련 문서
+
+- [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md) - 구현 계획
+- [QA_SQS_BATCHING.md](./QA_SQS_BATCHING.md) - SQS 배칭 Q&A

--- a/docs/QA_SQS_BATCHING.md
+++ b/docs/QA_SQS_BATCHING.md
@@ -1,0 +1,184 @@
+# Q&A: SQS 배칭을 통한 알림 통합 구조
+
+## Q1. 각 Scheduler가 독립적으로 실행되는데 어떻게 알림을 모아서 처리할 수 있나요?
+
+### 질문 배경
+- 각 EventBridge Scheduler는 자신의 ECS 서비스만 UpdateService 호출
+- Scheduler들은 서로의 존재를 모름
+- 그런데 어떻게 여러 서비스의 알림을 모아서 처리할 수 있는지?
+
+### 답변
+
+**핵심: 두 개의 독립된 경로가 존재**
+
+```
+[경로 1: 스케줄 실행 - 각각 독립]
+
+Scheduler-1 ──→ ECS UpdateService (nestjs)
+Scheduler-2 ──→ ECS UpdateService (python-api)
+Scheduler-3 ──→ ECS UpdateService (worker)
+     ...
+Scheduler-N ──→ ECS UpdateService (service-N)
+
+→ 각 Scheduler는 자기 서비스만 업데이트 (서로 모름)
+
+
+[경로 2: 알림 수집 - CloudTrail이 중앙에서 수집]
+
+                       ┌──────────────┐
+ECS UpdateService ────→│              │←──── ECS UpdateService
+ECS UpdateService ────→│  CloudTrail  │←──── ECS UpdateService
+ECS UpdateService ────→│  (AWS 자동)   │←──── ECS UpdateService
+                       └──────┬───────┘
+                              │
+                  모든 UpdateService API 호출 기록
+                              │
+                              ▼
+                  ┌───────────────────────┐
+                  │    EventBridge Rule   │
+                  │  (UpdateService 필터)  │
+                  └───────────┬───────────┘
+                              │
+                              ▼
+                  ┌───────────────────────┐
+                  │         SQS           │
+                  │  (메시지 N개 저장)     │
+                  └───────────┬───────────┘
+                              │
+                              ▼
+                  ┌───────────────────────┐
+                  │   Lambda (배치 처리)   │
+                  │   → Slack 요약 알림    │
+                  └───────────────────────┘
+```
+
+### 핵심 포인트
+
+| 구성요소 | 역할 |
+|---------|------|
+| **Scheduler** | 자기 서비스만 업데이트 (서로 독립적) |
+| **CloudTrail** | AWS 계정 내 모든 API 호출을 자동으로 중앙 기록 |
+| **EventBridge Rule** | CloudTrail에서 `UpdateService` 이벤트만 필터링 |
+| **SQS** | 필터링된 이벤트를 쌓아둠 |
+| **Lambda** | 모인 메시지를 배치로 처리 → 요약 알림 전송 |
+
+**결론: Scheduler들이 서로 연결되는 게 아니라, CloudTrail이 모든 API 호출을 수집하는 구조**
+
+---
+
+## Q2. SQS가 메시지를 모았다가 Lambda에 어떻게 전달하나요?
+
+### 질문 배경
+- SQS에 메시지가 쌓이는 건 이해함
+- 그런데 SQS가 어떻게 "모아서" Lambda에 전달하는지?
+- Lambda가 어떻게 여러 메시지를 한번에 인지하는지?
+
+### 답변
+
+**핵심: SQS가 아닌 Lambda Event Source Mapping이 배치 처리를 담당**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        SQS Queue                            │
+│  ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐       ┌─────┐     │
+│  │msg 1│ │msg 2│ │msg 3│ │msg 4│ │msg 5│  ...  │msg N│     │
+│  └─────┘ └─────┘ └─────┘ └─────┘ └─────┘       └─────┘     │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             │  Lambda Event Source Mapping:
+                             │  - batch_size = 10
+                             │  - maximum_batching_window = 300초
+                             │
+                             ▼
+              ┌──────────────────────────────┐
+              │  AWS가 자동으로 판단:         │
+              │  "10개 모였거나 5분 지났나?"   │
+              └──────────────┬───────────────┘
+                             │
+                             │ 조건 충족 시 Lambda 호출
+                             ▼
+              ┌──────────────────────────────┐
+              │         Lambda 함수          │
+              │                              │
+              │  event['Records'] = [        │
+              │    {body: nestjs 정보},      │
+              │    {body: python-api 정보},  │
+              │    {body: worker 정보},      │
+              │    ... (최대 10개)           │
+              │  ]                           │
+              └──────────────────────────────┘
+```
+
+### Terraform 설정
+
+```hcl
+resource "aws_lambda_event_source_mapping" "sqs_trigger" {
+  event_source_arn = aws_sqs_queue.alerts.arn
+  function_name    = aws_lambda_function.slack_notifier.arn
+
+  batch_size                         = 10   # 최대 10개씩 가져옴
+  maximum_batching_window_in_seconds = 300  # 최대 5분 대기
+}
+```
+
+### 트리거 조건
+
+| 조건 | 동작 |
+|------|------|
+| 메시지 10개 도달 | 즉시 Lambda 호출 |
+| 5분 경과 | 현재까지 모인 메시지로 Lambda 호출 |
+
+→ 둘 중 먼저 충족되는 조건으로 트리거
+
+### Lambda가 받는 event 구조
+
+```python
+{
+    "Records": [
+        {
+            "messageId": "abc-123",
+            "body": "{\"detail\": {\"requestParameters\": {\"service\": \"nestjs\", \"desiredCount\": 1}}}"
+        },
+        {
+            "messageId": "def-456",
+            "body": "{\"detail\": {\"requestParameters\": {\"service\": \"python-api\", \"desiredCount\": 1}}}"
+        },
+        # ... 배치된 메시지들
+    ]
+}
+```
+
+### Lambda 처리 로직
+
+```python
+def handler(event, context):
+    records = event['Records']  # 여러 메시지가 배열로 전달됨
+
+    results = []
+    for record in records:
+        body = json.loads(record['body'])
+        service_name = body['detail']['requestParameters']['service']
+        desired_count = body['detail']['requestParameters']['desiredCount']
+        results.append({'service': service_name, 'count': desired_count})
+
+    # 모은 결과를 한번에 Slack으로 전송
+    send_summary_to_slack(results)
+```
+
+### 핵심 포인트
+
+| 오해 | 실제 |
+|------|------|
+| SQS가 메시지를 모아서 보냄 | SQS는 단순 저장소 (큐) |
+| SQS가 Lambda를 호출함 | Lambda Event Source Mapping이 SQS를 폴링 |
+| Lambda가 메시지를 하나씩 받음 | batch_size 설정에 따라 여러 개를 배열로 받음 |
+
+**결론: SQS는 단순 저장소이고, AWS Lambda Event Source Mapping이 배치 처리를 담당**
+
+---
+
+## 관련 문서
+
+- [AWS Lambda - SQS Event Source Mapping](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)
+- [AWS SQS - Batching](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-batch-api-actions.html)
+- [CloudTrail - Event Reference](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html)

--- a/docs/implementation/1-implementation-plan.md
+++ b/docs/implementation/1-implementation-plan.md
@@ -1,0 +1,65 @@
+## 📝 Implementation Plan: Filter ECS Scheduler Notifications
+
+The goal of this plan is to reduce alert fatigue by filtering ECS `UpdateService` notifications in Slack so that **only** updates triggered by the EventBridge Scheduler are sent.
+
+-----
+
+### ⚠️ User Review Required
+
+> [\!IMPORTANT]
+> This change relies critically on the naming convention of the IAM Role created by the `ecs-scheduler` module. The IAM Role name **MUST** end with the suffix:
+>
+> `**-scheduler-role-${var.environment}**`
+>
+> If this naming convention is changed in the future, the CloudWatch Event Rule filter will need to be updated.
+
+-----
+
+### ⚙️ Proposed Changes
+
+The change involves modifying the CloudWatch Event Rule in the `slack-notifier` module to include a filter that checks the identity of the user/role that triggered the ECS `UpdateService` API call.
+
+#### Module: `modules/slack-notifier`
+
+#### **[MODIFY] `main.tf`**
+
+Update the `aws_cloudwatch_event_rule.ecs_update_service` resource's `event_pattern` to include a `userIdentity` filter that specifically matches the scheduler's IAM Role name using the `suffix` operator.
+
+```hcl
+  event_pattern = jsonencode({
+    source      = ["aws.ecs"]
+    detail-type = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventName = ["UpdateService"]
+      # The new filter logic
+      userIdentity = {
+        sessionContext = {
+          sessionIssuer = {
+            # Only match callers whose userName (the IAM Role name) ends with the scheduler's specific suffix
+            userName = [{ "suffix": "-scheduler-role-${var.environment}" }]
+          }
+        }
+      }
+    }
+  })
+```
+
+-----
+
+### ✅ Verification Plan
+
+Verification relies on manual observation of Slack notifications after applying the changes and triggering different types of service updates.
+
+#### **Manual Verification**
+
+1.  **Apply Terraform:** Apply the changes to the **`dev`** environment.
+2.  **Trigger Scheduler Update (Expected: Notification RECEIVED):**
+      * Wait for a naturally scheduled scale-up/down event.
+      * *OR* Manually trigger the EventBridge schedule via the AWS Console/CLI.
+      * **Check:** Verify that a Slack notification is **RECEIVED**.
+3.  **Manual Console Update (Expected: Notification BLOCKED):**
+      * Go to the AWS Console -\> ECS -\> Service -\> Update Service -\> Force new deployment or manually change the task count.
+      * **Check:** Verify that **NO** Slack notification is received.
+4.  **Terraform Update (Expected: Notification BLOCKED):**
+      * Run `terraform apply` to change a different property of the ECS service (e.g., CPU/Memory, or a non-scaling related tag).
+      * **Check:** Verify that **NO** Slack notification is received.

--- a/modules/slack-notifier/main.tf
+++ b/modules/slack-notifier/main.tf
@@ -114,6 +114,15 @@ resource "aws_cloudwatch_event_rule" "ecs_update_service" {
     detail-type = ["AWS API Call via CloudTrail"]
     detail = {
       eventName = ["UpdateService"]
+      # The new filter logic
+      userIdentity = {
+        sessionContext = {
+          sessionIssuer = {
+            # Only match callers whose userName (the IAM Role name) ends with the scheduler's specific suffix
+            userName = [{ "suffix": "-scheduler-role-${var.environment}" }]
+          }
+        }
+      }
     }
   })
 }


### PR DESCRIPTION
This PR addresses alert fatigue by implementing a precise filter on the CloudWatch Event Rule responsible for sending ECS UpdateService notifications to Slack. After this change, the Slack notifier will only trigger for ECS service updates that are explicitly initiated by the EventBridge Scheduler module's dedicated IAM Role.

All manual console updates, Terraform provisioning runs, and other non-scheduler updates will be blocked from sending notifications.

---

File Modified: modules/slack-notifier/main.tf

(AS-IS): The rule matched any AWS API Call via CloudTrail with eventName = ["UpdateService"].

(TO-BE): The rule now requires an additional filter path: detail.userIdentity.sessionContext.sessionIssuer.userName

This path must match the expected naming convention for the scheduler's IAM Role, which ends with **-scheduler-role-${var.environment}**